### PR TITLE
Add flex alignment to tags in `PostPage.astro`

### DIFF
--- a/src/components/astro/posts/PostPage.astro
+++ b/src/components/astro/posts/PostPage.astro
@@ -35,7 +35,7 @@ const {
             return (
               <li
                 data-pagefind-filter={"Topics"}
-                class="badge badge-primary badge-outline badge-sm"
+                class="badge badge-primary badge-outline badge-sm flex items-end"
               >
                 {tag}
               </li>


### PR DESCRIPTION
Hey, крышечка! I really like your website and the post! Didn't dive too deep into the code, but one minor detail caught my eye. This PR adds `flex items-end` classes to the tag elements in `PostPage.astro` to vertically align the text within the badges, matching the look you have in the `PostCard.astro` component.

Feel free to accept or decline this PR, just a minor touch!